### PR TITLE
Update Payone.php

### DIFF
--- a/lib/custom/src/MShop/Service/Provider/Payment/Payone.php
+++ b/lib/custom/src/MShop/Service/Provider/Payment/Payone.php
@@ -44,7 +44,7 @@ class Payone
 				'itemType' => 'goods', // Available types: goods, shipping etc.
 				'quantity' => $product->getQuantity(),
 				'price' => $product->getPrice()->getValue(),
-				'vat' => (int) $base->getPrice()->getTaxFlag(),
+				'vat' => (int) $product->getPrice()->getTaxRate(),
 			]);
 		}
 
@@ -56,7 +56,7 @@ class Payone
 				'itemType' => 'shipment',
 				'quantity' => 1,
 				'price' => $delivery->getPrice()->getCosts(),
-				'vat' => (int) $base->getPrice()->getTaxFlag(),
+				'vat' => (int) $delivery->getPrice()->getTaxRate(),
 			]);
 
 			$completePrice = (string) ( (float) $delivery->getPrice()->getCosts() + (float) $completePrice );


### PR DESCRIPTION
Because the tax rate was apparently not correctly calculated, the tax rate calculation was changed, so that the tax rate then was correctly sent to PAYONE:

replaced 'vat' => (int) $base->getPrice()->getTaxFlag(), by
'vat' => (int) $product->getPrice()->getTaxRate(),

replaced 'vat' => (int) $base->getPrice()->getTaxFlag(), by
'vat' => (int) $delivery->getPrice()->getTaxRate(),

Maybe you could have a look at it? Feel free to change or improve something! Thank you!