### PR TITLE
Implement Orders API for pay later payment methods

### DIFF
--- a/lib/custom/src/MShop/Service/Provider/Payment/Mollie.php
+++ b/lib/custom/src/MShop/Service/Provider/Payment/Mollie.php
@@ -47,4 +47,251 @@ class Mollie
 
 		return parent::getValue( $key, $default );
 	}
+	
+	/**
+	 * Returns Omnipay items array
+	 *
+	 * @param \Aimeos\MShop\Order\Item\Base\Iface $base Order base object with addresses and services
+	 * @param array $params POST parameters passed to the provider
+	 * @return Array of items
+	 */
+	protected function getItems( \Aimeos\MShop\Order\Item\Base\Iface $base, array $params )
+	{
+		$items = array();
+		foreach( $base->getProducts() as $product ) {
+			$price = $product->getPrice();
+			$items[] = array(
+				'sku' => $product->getProductCode(),
+				'name' => $product->getName(),
+				'quantity' => $product->getQuantity(),
+				'vatRate' => $price->getTaxRate(),
+				'unitPrice' => round( $price->getValue(), 2),
+				'totalAmount' => round( $price->getValue() * $product->getQuantity(), 2),
+				'vatAmount' => round( $price->getTaxValue() * $product->getQuantity(), 2),
+			);
+		}
+		return $items;
+	}
+	
+	/**
+	 * Returns the data passed to the Omnipay library
+	 *
+	 * @param \Aimeos\MShop\Order\Item\Base\Iface $base Basket object
+	 * @param $orderid Unique order ID
+	 * @param array $params Request parameter if available
+	 */
+	protected function getData( \Aimeos\MShop\Order\Item\Base\Iface $base, $orderid, array $params )
+	{
+		$data = array(
+			'orderNumber' => $orderid
+		);
+
+		return $data + parent::getData( $base, $orderid, $params );
+	}
+	
+	/**
+	 * Updates the orders for whose status updates have been received by the confirmation page
+	 *
+	 * @param \Psr\Http\Message\ServerRequestInterface $request Request object with parameters and request body
+	 * @param \Aimeos\MShop\Order\Item\Iface $order Order item that should be updated
+	 * @return \Aimeos\MShop\Order\Item\Iface Updated order item
+	 * @throws \Aimeos\MShop\Service\Exception If updating the orders failed
+	 */
+	public function updateSync( \Psr\Http\Message\ServerRequestInterface $request, \Aimeos\MShop\Order\Item\Iface $order )
+	{
+		try
+		{
+			$provider = $this->getProvider();
+			$base = $this->getOrderBase( $order->getBaseId() );
+
+			$params = (array) $request->getAttributes() + (array) $request->getParsedBody() + (array) $request->getQueryParams();
+			$params['transactionId'] = $order->getId();
+			$params['transactionReference'] = $this->getTransactionReference( $base );
+			$params['amount'] = $this->getAmount( $base->getPrice() );
+			$params['currency'] = $base->getLocale()->getCurrencyId();
+			$params['createCard'] = true;
+
+			if( $this->getValue( 'authorize', false ) && $provider->supportsCompleteAuthorize() )
+			{
+				$response = $provider->completeAuthorize( $params )->send();
+				$status = \Aimeos\MShop\Order\Item\Base::PAY_AUTHORIZED;
+			}
+			elseif( $this->getValue('apiType', 'payment') == 'order' )
+			{
+				$response = $provider->completeOrder( $params )->send();
+				$status = \Aimeos\MShop\Order\Item\Base::PAY_RECEIVED;
+			}
+			elseif( $provider->supportsCompletePurchase() )
+			{
+				$response = $provider->completePurchase( $params )->send();
+				$status = \Aimeos\MShop\Order\Item\Base::PAY_RECEIVED;
+			}
+			else
+			{
+				return $order;
+			}
+
+			if( method_exists( $response, 'isSuccessful' ) && $response->isSuccessful() )
+			{
+				$order->setPaymentStatus( $status );
+			}
+			elseif( method_exists( $response, 'isAuthorized' ) && $response->isAuthorized() )
+			{
+				$order->setPaymentStatus( \Aimeos\MShop\Order\Item\Base::PAY_AUTHORIZED );
+			}
+			elseif( method_exists( $response, 'isPending' ) && $response->isPending() )
+			{
+				$order->setPaymentStatus( \Aimeos\MShop\Order\Item\Base::PAY_PENDING );
+			}
+			elseif( method_exists( $response, 'isOpen' ) && $response->isOpen() )
+			{
+				$order->setPaymentStatus( \Aimeos\MShop\Order\Item\Base::PAY_REFUSED );
+			}
+			elseif( method_exists( $response, 'isCancelled' ) && $response->isCancelled() )
+			{
+				$order->setPaymentStatus( \Aimeos\MShop\Order\Item\Base::PAY_CANCELED );
+			}
+			elseif( method_exists( $response, 'isRedirect' ) && $response->isRedirect() )
+			{
+				$url = $response->getRedirectUrl();
+				throw new \Aimeos\MShop\Service\Exception( sprintf( 'Unexpected redirect: %1$s', $url ) );
+			}
+			else
+			{
+				$this->saveOrder( $order->setPaymentStatus( \Aimeos\MShop\Order\Item\Base::PAY_REFUSED ) );
+				throw new \Aimeos\MShop\Service\Exception( $response->getMessage() );
+			}
+
+			$this->saveTransationRef( $base, $response->getTransactionReference() );
+			$this->saveRepayData( $response, $base->getCustomerId() );
+			$this->saveOrder( $order );
+		}
+		catch( \Exception $e )
+		{
+			throw new \Aimeos\MShop\Service\Exception( $e->getMessage() );
+		}
+
+		return $order;
+	}
+	
+	/**
+	 * Tries to get an authorization or captures the money immediately for the given order if capturing the money
+	 * separately isn't supported or not configured by the shop owner.
+	 *
+	 * @param \Aimeos\MShop\Order\Item\Iface $order Order invoice object
+	 * @param array $params Request parameter if available
+	 * @return \Aimeos\MShop\Common\Item\Helper\Form\Standard Form object with URL, action and parameters to redirect to
+	 * 	(e.g. to an external server of the payment provider or to a local success page)
+	 */
+	protected function processOrder( \Aimeos\MShop\Order\Item\Iface $order, array $params = [] )
+	{
+		error_log('## AIPAY:MOLLIE customProcessOrder ##');
+		$parts = \Aimeos\MShop\Order\Item\Base\Base::PARTS_SERVICE
+			| \Aimeos\MShop\Order\Item\Base\Base::PARTS_PRODUCT
+			| \Aimeos\MShop\Order\Item\Base\Base::PARTS_ADDRESS;
+
+		$base = $this->getOrderBase( $order->getBaseId(), $parts );
+		$data = $this->getData( $base, $order->getId(), $params );
+		$urls = $this->getPaymentUrls();
+
+		try
+		{
+			$provider = $this->getProvider();
+
+			if( $this->getValue( 'authorize', false ) && $provider->supportsAuthorize() )
+			{
+				$response = $provider->authorize( $data )->send();
+				$status = \Aimeos\MShop\Order\Item\Base::PAY_AUTHORIZED;
+			}
+			elseif( $this->getValue( 'apiType', '' ) === 'order' )
+			{
+				$response = $provider->createOrder( $data )->setItems( $this->getItems( $base, $params ) )->send();
+				$status = \Aimeos\MShop\Order\Item\Base::PAY_AUTHORIZED;
+			}
+			else
+			{
+				$response = $provider->purchase( $data )->send();
+				$status = \Aimeos\MShop\Order\Item\Base::PAY_RECEIVED;
+			}
+
+			if( $response->isSuccessful() )
+			{
+				$this->saveTransationRef( $base, $response->getTransactionReference() );
+
+				$order->setPaymentStatus( $status );
+				$this->saveOrder( $order );
+			}
+			elseif( $response->isRedirect() )
+			{
+				if( ( $ref = $response->getTransactionReference() ) != null ) {
+					$this->saveTransationRef( $base, $ref );
+				}
+
+				return $this->getRedirectForm( $response );
+			}
+			else
+			{
+				$order->setPaymentStatus( \Aimeos\MShop\Order\Item\Base::PAY_REFUSED );
+				$this->saveOrder( $order );
+
+				throw new \Aimeos\MShop\Service\Exception( $response->getMessage() );
+			}
+		}
+		catch( \Exception $e )
+		{
+			throw new \Aimeos\MShop\Service\Exception( $e->getMessage() );
+		}
+
+		return new \Aimeos\MShop\Common\Item\Helper\Form\Standard( $urls['returnUrl'], 'POST', [] );
+	}
+	
+	/**
+	 * Returns an Omnipay credit card object, except for phone numbers as Mollie requests a strict number
+	 * format which we can not provice in all cases.
+	 *
+	 * @param \Aimeos\MShop\Order\Item\Base\Iface $base Order base object with addresses and services
+	 * @param array $params POST parameters passed to the provider
+	 * @return \Omnipay\Common\CreditCard Credit card object
+	 */
+	protected function getCardDetails( \Aimeos\MShop\Order\Item\Base\Iface $base, array $params )
+	{
+		if( $this->getValue( 'address' ) )
+		{
+			$addresses = $base->getAddresses();
+
+			if( isset( $addresses[\Aimeos\MShop\Order\Item\Base\Address\Base::TYPE_PAYMENT ] ) )
+			{
+				$addr = $addresses[\Aimeos\MShop\Order\Item\Base\Address\Base::TYPE_PAYMENT];
+
+				$params['billingName'] = $addr->getFirstname() . ' ' . $addr->getLastname();
+				$params['billingFirstName'] = $addr->getFirstname();
+				$params['billingLastName'] = $addr->getLastname();
+				$params['billingCompany'] = $addr->getCompany();
+				$params['billingAddress1'] = $addr->getAddress1();
+				$params['billingAddress2'] = $addr->getAddress2();
+				$params['billingCity'] = $addr->getCity();
+				$params['billingPostcode'] = $addr->getPostal();
+				$params['billingState'] = $addr->getState();
+				$params['billingCountry'] = $addr->getCountryId();
+				$params['email'] = $addr->getEmail();
+
+				if( isset( $addresses[\Aimeos\MShop\Order\Item\Base\Address\Base::TYPE_DELIVERY ] ) ) {
+					$addr = $addresses[\Aimeos\MShop\Order\Item\Base\Address\Base::TYPE_DELIVERY];
+				}
+
+				$params['shippingName'] = $addr->getFirstname() . ' ' . $addr->getLastname();
+				$params['shippingFirstName'] = $addr->getFirstname();
+				$params['shippingLastName'] = $addr->getLastname();
+				$params['shippingCompany'] = $addr->getCompany();
+				$params['shippingAddress1'] = $addr->getAddress1();
+				$params['shippingAddress2'] = $addr->getAddress2();
+				$params['shippingCity'] = $addr->getCity();
+				$params['shippingPostcode'] = $addr->getPostal();
+				$params['shippingState'] = $addr->getState();
+				$params['shippingCountry'] = $addr->getCountryId();
+			}
+		}
+
+		return new \Omnipay\Common\CreditCard( $params );
+	}
 }

--- a/lib/custom/src/MShop/Service/Provider/Payment/Mollie.php
+++ b/lib/custom/src/MShop/Service/Provider/Payment/Mollie.php
@@ -21,6 +21,58 @@ class Mollie
 	extends \Aimeos\MShop\Service\Provider\Payment\OmniPay
 	implements \Aimeos\MShop\Service\Provider\Payment\Iface
 {
+	private $beConfig = array(
+		'mollie.locale' => array(
+			'code' => 'mollie.locale',
+			'internalcode'=> 'mollie.locale',
+			'label'=> 'Locale for orders API (e.g. en_US)',
+			'type'=> 'string',
+			'internaltype'=> 'string',
+			'default'=> '',
+			'required'=> false,
+		),
+		'mollie.paymentmethod' => array(
+			'code' => 'mollie.paymentmethod',
+			'internalcode'=> 'mollie.paymentmethod',
+			'label'=> 'Preselect Mollie payment method (e.g. creditcard)',
+			'type'=> 'string',
+			'internaltype'=> 'string',
+			'default'=> '',
+			'required'=> false,
+		),
+	);
+
+	/**
+	 * Returns the configuration attribute definitions of the provider to generate a list of available fields and
+	 * rules for the value of each field in the administration interface.
+	 *
+	 * @return array List of attribute definitions implementing \Aimeos\MW\Common\Critera\Attribute\Iface
+	 */
+	public function getConfigBE()
+	{
+		$list = parent::getConfigBE();
+
+		foreach( $this->beConfig as $key => $config )
+		{
+			$config['code'] = $config['code'];
+			$list[$key] = new \Aimeos\MW\Criteria\Attribute\Standard( $config );
+		}
+
+		return $list;
+	}
+
+	/**
+	 * Checks the backend configuration attributes for validity.
+	 *
+	 * @param array $attributes Attributes added by the shop owner in the administraton interface
+	 * @return array An array with the attribute keys as key and an error message as values for all attributes that are
+	 * 	known by the provider but aren't valid
+	 */
+	public function checkConfigBE( array $attributes )
+	{
+		return array_merge( parent::checkConfigBE( $attributes ), $this->checkConfig( $this->beConfig, $attributes ) );
+	}
+
 	/**
 	 * Returns the prefix for the configuration definitions
 	 *
@@ -137,6 +189,14 @@ class Mollie
 		$data = array(
 			'orderNumber' => $orderid
 		);
+
+		if( $locale = $this->getValue('locale') ) {
+			$data['locale'] = $locale;
+		}
+
+		if( $method = $this->getValue('paymentmethod') ) {
+			$data['paymentMethod'] = $method;
+		}
 
 		return $data + parent::getData( $base, $orderid, $params );
 	}

--- a/lib/custom/src/MShop/Service/Provider/Payment/Mollie.php
+++ b/lib/custom/src/MShop/Service/Provider/Payment/Mollie.php
@@ -75,12 +75,12 @@ class Mollie
 
 			$itemShippingCosts = floatval( $price->getCosts() * $product->getQuantity() );
 			if( $itemShippingCosts != 0 ) {
-				$itemShippingCostsTax = ( $price->getTaxValue() * $product->getQuantity() ) - $unitTax;
+				$itemShippingCostsTax = $itemShippingCosts - $itemShippingCosts / ( ( floatval( $price->getTaxRate() ) + 100 ) / 100 );
 				$items[] = array(
 					'name' => $i18n->dt( 'mshop', 'Item shipping costs' ),
 					'type' => 'shipping_fee',
 					'quantity' => 1,
-					'vatRate' => round( ( $itemShippingCostsTax * 100 ) / ( $itemShippingCosts - $itemShippingCostsTax ) ),
+					'vatRate' => $price->getTaxRate(),
 					'unitPrice' => round( $itemShippingCosts, 2),
 					'totalAmount' => round( $itemShippingCosts, 2),
 					'vatAmount' => round( $itemShippingCostsTax, 2)
@@ -92,30 +92,34 @@ class Mollie
 		{
 			$deliveryPriceItem = $service->getPrice();
 
-			$items[] = array(
-				'name' => $i18n->dt( 'mshop', 'Shipping' ),
-				'type' => 'shipping_fee',
-				'quantity' => 1,
-				'vatRate' => $deliveryPriceItem->getTaxRate(),
-				'unitPrice' => round( $deliveryPriceItem->getCosts() + $deliveryPriceItem->getValue(), 2),
-				'totalAmount' => round( $deliveryPriceItem->getCosts() + $deliveryPriceItem->getValue(), 2),
-				'vatAmount' => round( $deliveryPriceItem->getTaxValue(), 2),
-			);
+			if( $deliveryPriceItem && $deliveryPriceItem->getCosts() + $deliveryPriceItem->getValue() > 0 ) {
+				$items[] = array(
+					'name' => $i18n->dt( 'mshop', 'Shipping' ),
+					'type' => 'shipping_fee',
+					'quantity' => 1,
+					'vatRate' => $deliveryPriceItem->getTaxRate(),
+					'unitPrice' => round( $deliveryPriceItem->getCosts() + $deliveryPriceItem->getValue(), 2),
+					'totalAmount' => round( $deliveryPriceItem->getCosts() + $deliveryPriceItem->getValue(), 2),
+					'vatAmount' => round( $deliveryPriceItem->getTaxValue(), 2),
+				);
+			}
 		}
 
 		foreach( $base->getService( 'payment' ) as $service )
 		{
 			$paymentPriceItem = $service->getPrice();
 
-			$items[] = array(
-				'name' => $i18n->dt( 'mshop', 'Payment costs' ),
-				'type' => 'surcharge',
-				'quantity' => 1,
-				'vatRate' => $paymentPriceItem->getTaxRate(),
-				'unitPrice' => round( $paymentPriceItem->getCosts() + $paymentPriceItem->getValue(), 2),
-				'totalAmount' => round( $paymentPriceItem->getCosts() + $paymentPriceItem->getValue(), 2),
-				'vatAmount' => round( $paymentPriceItem->getTaxValue(), 2),
-			);
+			if( $paymentPriceItem && $paymentPriceItem->getCosts() + $paymentPriceItem->getValue() > 0 ) {
+				$items[] = array(
+					'name' => $i18n->dt( 'mshop', 'Payment costs' ),
+					'type' => 'surcharge',
+					'quantity' => 1,
+					'vatRate' => $paymentPriceItem->getTaxRate(),
+					'unitPrice' => round( $paymentPriceItem->getCosts() + $paymentPriceItem->getValue(), 2),
+					'totalAmount' => round( $paymentPriceItem->getCosts() + $paymentPriceItem->getValue(), 2),
+					'vatAmount' => round( $paymentPriceItem->getTaxValue(), 2),
+				);
+			}
 		}
 
 		return $items;

--- a/lib/custom/src/MShop/Service/Provider/Payment/Mollie.php
+++ b/lib/custom/src/MShop/Service/Provider/Payment/Mollie.php
@@ -185,7 +185,6 @@ class Mollie
 	 */
 	protected function processOrder( \Aimeos\MShop\Order\Item\Iface $order, array $params = [] )
 	{
-		error_log('## AIPAY:MOLLIE customProcessOrder ##');
 		$parts = \Aimeos\MShop\Order\Item\Base\Base::PARTS_SERVICE
 			| \Aimeos\MShop\Order\Item\Base\Base::PARTS_PRODUCT
 			| \Aimeos\MShop\Order\Item\Base\Base::PARTS_ADDRESS;

--- a/lib/custom/src/MShop/Service/Provider/Payment/Mollie.php
+++ b/lib/custom/src/MShop/Service/Provider/Payment/Mollie.php
@@ -70,7 +70,7 @@ class Mollie
 				'vatRate' => $price->getTaxRate(),
 				'unitPrice' => round( $price->getValue(), 2),
 				'totalAmount' => round( $price->getValue() * $product->getQuantity(), 2),
-				'vatAmount' => round( $unitTax, 2),
+				'vatAmount' => round( $unitTax * $product->getQuantity(), 2),
 			);
 
 			$itemShippingCosts = floatval( $price->getCosts() * $product->getQuantity() );

--- a/lib/custom/src/MShop/Service/Provider/Payment/Mollie.php
+++ b/lib/custom/src/MShop/Service/Provider/Payment/Mollie.php
@@ -350,7 +350,14 @@ class Mollie
 		}
 		catch( \Exception $e )
 		{
-			throw new \Aimeos\MShop\Service\Exception( $e->getMessage() );
+			$message = $e->getMessage();
+			$this->getContext()->getLogger()->log( $message, \Aimeos\MW\Logger\Base::WARN, 'payment' );
+
+			if( ( $data = json_decode( $message, true ) ) !== null ) {
+				$message = $this->getContext()->getI18n()->dt( 'mshop', $data['detail'] );
+			}
+
+			throw new \Aimeos\MShop\Service\Exception( $message );
 		}
 
 		return new \Aimeos\MShop\Common\Item\Helper\Form\Standard( $urls['returnUrl'], 'POST', [] );

--- a/lib/custom/tests/MShop/Service/Provider/Payment/MollieTest.php
+++ b/lib/custom/tests/MShop/Service/Provider/Payment/MollieTest.php
@@ -29,7 +29,7 @@ class MollieTest extends \PHPUnit\Framework\TestCase
 		$item->setCode( 'OGONE' );
 
 		$this->object = $this->getMockBuilder( 'Aimeos\MShop\Service\Provider\Payment\MolliePublic' )
-			->setMethods( array( 'getOrder', 'getOrderBase', 'saveOrder', 'saveOrderBase', 'getProvider' ) )
+			->setMethods( array( 'getOrder', 'getOrderBase', 'getTransactionReference', 'saveOrder', 'saveOrderBase', 'getProvider' ) )
 			->setConstructorArgs( array( $this->context, $item ) )
 			->getMock();
 	}
@@ -50,6 +50,129 @@ class MollieTest extends \PHPUnit\Framework\TestCase
 	public function testGetValueTestmode()
 	{
 		$this->assertTrue( $this->object->getValuePublic( 'testmode' ) );
+	}
+	
+	public function testUpdateSync()
+	{
+		$baseItem = $this->getOrderBase( \Aimeos\MShop\Order\Item\Base\Base::PARTS_SERVICE );
+
+		$psr7request = $this->getMockBuilder( '\Psr\Http\Message\ServerRequestInterface' )->getMock();
+
+		$provider = $this->getMockBuilder( 'Omnipay\Dummy\Gateway' )
+			->setMethods( array( 'authorize' ) )
+			->getMock();
+
+		$this->object->expects( $this->once() )->method( 'getOrderBase' )
+			->will( $this->returnValue( $baseItem ) );
+
+		$this->object->expects( $this->once() )->method( 'getProvider' )
+			->will( $this->returnValue( $provider ) );
+
+		$this->object->expects( $this->once() )->method( 'getTransactionReference' )
+			->will( $this->returnValue( '123' ) );
+
+
+		$result = $this->object->updateSync( $psr7request, $this->getOrder() );
+
+		$this->assertInstanceOf( '\\Aimeos\\MShop\\Order\\Item\\Iface', $result );
+	}
+
+
+	public function testUpdateSyncNone()
+	{
+		$baseItem = $this->getOrderBase( \Aimeos\MShop\Order\Item\Base\Base::PARTS_SERVICE );
+
+
+		$provider = $this->getMockBuilder( 'Omnipay\Dummy\Gateway' )
+			->setMethods( array( 'supportsCompletePurchase', 'completePurchase' ) )
+			->getMock();
+
+		$psr7request = $this->getMockBuilder( '\Psr\Http\Message\ServerRequestInterface' )->getMock();
+
+		$this->object->expects( $this->once() )->method( 'getOrderBase' )
+			->will( $this->returnValue( $baseItem ) );
+
+		$this->object->expects( $this->once() )->method( 'getProvider' )
+			->will( $this->returnValue( $provider ) );
+
+
+		$result = $this->object->updateSync( $psr7request, $this->getOrder() );
+
+		$this->assertInstanceOf( '\\Aimeos\\MShop\\Order\\Item\\Iface', $result );
+	}
+
+
+	public function testUpdateSyncPurchaseSucessful()
+	{
+		$baseItem = $this->getOrderBase( \Aimeos\MShop\Order\Item\Base\Base::PARTS_SERVICE );
+
+
+		$provider = $this->getMockBuilder( 'Omnipay\Dummy\Gateway' )
+			->setMethods( array( 'supportsCompletePurchase', 'completePurchase' ) )
+			->getMock();
+
+		$request = $this->getMockBuilder( '\Omnipay\Dummy\Message\AuthorizeRequest' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'send' ) )
+			->getMock();
+
+		$response = $this->getMockBuilder( 'Omnipay\Dummy\Message\Response' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'isSuccessful' ) )
+			->getMock();
+
+		$psr7request = $this->getMockBuilder( '\Psr\Http\Message\ServerRequestInterface' )->getMock();
+
+
+		$this->object->expects( $this->once() )->method( 'getOrderBase' )
+			->will( $this->returnValue( $baseItem ) );
+
+		$this->object->expects( $this->once() )->method( 'getProvider' )
+			->will( $this->returnValue( $provider ) );
+
+		$provider->expects( $this->once() )->method( 'supportsCompletePurchase' )
+			->will( $this->returnValue( true ) );
+
+		$provider->expects( $this->once() )->method( 'completePurchase' )
+			->will( $this->returnValue( $request ) );
+
+		$request->expects( $this->once() )->method( 'send' )
+			->will( $this->returnValue( $response ) );
+
+		$response->expects( $this->once() )->method( 'isSuccessful' )
+			->will( $this->returnValue( true ) );
+
+
+		$result = $this->object->updateSync( $psr7request, $this->getOrder() );
+
+		$this->assertInstanceOf( '\\Aimeos\\MShop\\Order\\Item\\Iface', $result );
+	}
+
+	protected function getOrder()
+	{
+		$manager = \Aimeos\MShop\Order\Manager\Factory::createManager( $this->context );
+
+		$search = $manager->createSearch();
+		$search->setConditions( $search->compare( '==', 'order.datepayment', '2008-02-15 12:34:56' ) );
+
+		$result = $manager->searchItems( $search );
+
+		if( ( $item = reset( $result ) ) === false ) {
+			throw new \RuntimeException( 'No order found' );
+		}
+
+		return $item;
+	}
+
+	protected function getOrderBase( $parts = null )
+	{
+		if( $parts === null ) {
+			$parts = \Aimeos\MShop\Order\Item\Base\Base::PARTS_ADDRESS | \Aimeos\MShop\Order\Item\Base\Base::PARTS_SERVICE;
+		}
+
+		$manager = \Aimeos\MShop\Order\Manager\Factory::createManager( $this->context )->getSubmanager( 'base' );
+
+		return $manager->load( $this->getOrder()->getBaseId(), $parts );
 	}
 }
 


### PR DESCRIPTION
This patch overrides a couple of Omnipay methods to implement the Mollie Orders API, which is needed for Klarna Pay later and Klarna Slice payment options. 

I was not sure if it would be cleaner to modify some methods at `Aimeos\MShop\Service\Provider\Payment\Omnipay` directly, but ultimately decided to do it like this. Feel free to adapt or modify.