### PR TITLE
enable use of composer 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 	"require": {
 		"php": "~7.1",
 		"aimeos/aimeos-core": "dev-master",
-		"composer/installers": "^1.0",
+		"composer/installers": "^1.0 || ^2.0",
 		"omnipay/common": "~3.0",
 		"php-http/httplug": "~2.0",
 		"php-http/curl-client": "~2.0"


### PR DESCRIPTION
There might be slight changes with composer/installers https://getcomposer.org/upgrade/UPGRADE-2.0.md
But AFAIS the way this package uses it (use official installer with registered package type) did not change the API.