### PR TITLE
Fix: return type incompatible with base class

### DIFF
--- a/lib/custom/src/MShop/Service/Provider/Payment/Mpay24.php
+++ b/lib/custom/src/MShop/Service/Provider/Payment/Mpay24.php
@@ -26,9 +26,9 @@ class Mpay24
 	 * This requires support of the payment gateway and token based payment
 	 *
 	 * @param \Aimeos\MShop\Order\Item\Iface $order Order invoice object
-	 * @return void
+	 * @return \Aimeos\MShop\Order\Item\Iface
 	 */
-	public function repay( \Aimeos\MShop\Order\Item\Iface $order )
+	public function repay( \Aimeos\MShop\Order\Item\Iface $order ): \Aimeos\MShop\Order\Item\Iface
 	{
 		$base = $this->getOrderBase( $order->getBaseId(), \Aimeos\MShop\Order\Item\Base\Base::PARTS_ADDRESS );
 


### PR DESCRIPTION
The repay() method in Mpay24 is not  compatible with the base class implementation.

![5d126649-7feb-4c0c-9c71-eb2100d63c76](https://user-images.githubusercontent.com/33923690/115537519-2e93c980-a29b-11eb-92cc-a9ee2bc80465.jpg)
