### PR TITLE
Implement Stripe Multiple API Key

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 	"prefer-stable": true,
 	"minimum-stability": "dev",
 	"require": {
-		"php": "~7.1||~8.0",
+		"php": "~7.1||^8.0.10",
 		"aimeos/aimeos-core": "dev-master",
 		"omnipay/common": "~3.0",
 		"php-http/httplug": "~2.0",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
 	"prefer-stable": true,
 	"minimum-stability": "dev",
 	"require": {
-		"php": "~7.1||^8.0.10",
 		"aimeos/aimeos-core": "dev-master",
 		"omnipay/common": "~3.0",
 		"php-http/httplug": "~2.0",

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
 	"prefer-stable": true,
 	"minimum-stability": "dev",
 	"require": {
+		"php": "~7.1||^8.0",
 		"aimeos/aimeos-core": "dev-master",
 		"omnipay/common": "~3.0",
 		"php-http/httplug": "~2.0",


### PR DESCRIPTION
### Changes
Add the ability to handle Stripe Multiple API Key based on currency available.

### Configuration
Refer to the existing configuration options listed [on ai-payments aimeos documentation](https://aimeos.org/docs/2021.x/manual/services/#stripe) 

We added 1 static configuration (built-in/merged with existing config):

- multiCurrency (boolean, optional)
Accept 0/1, use 1 to enable multiple stripe account

We also added 2 dynamic configuration options (inserted manually through the admin panel)

1. apiKey_{currency_code}

example option name: apiKey_AUD
value can be filled by the secret API key string from your Stripe account.

2. publishableKey_{currency_code}

example option name: publishableKey_AUD
value can be filled by publishable API key string from your Stripe account.

### Behavior

2 dynamic config values will be read by the system if multiCurrency was enabled. If enabled but system doesn’t detect related apiKey with currency in the shopping cart, system will use the default Stripe account (default value from apiKey and publishableKey)

### Additional Notes

currency_code values taken from what aimeos locale currencies list (ISO 4217)